### PR TITLE
Save generated images to separate folder and add option to generate video on completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 Small script for AUTOMATIC1111/stable-diffusion-webui to create images that exists between seeds.
 
 Installation:
-Copy the file in the scripts-folder to the scripts-folder from https://github.com/AUTOMATIC1111/stable-diffusion-webui
+1. Copy the file in the scripts-folder to the scripts-folder from https://github.com/AUTOMATIC1111/stable-diffusion-webui
+2. Add `moviepy==1.0.3` to requirements_versions.txt
 
 Will let you pick two seeds (or more) and then create a number of images while it morph between the two points of noise generated.
 

--- a/scripts/seed_travel.py
+++ b/scripts/seed_travel.py
@@ -1,3 +1,4 @@
+import os
 import modules.scripts as scripts
 import gradio as gr
 import math
@@ -15,17 +16,44 @@ class Script(scripts.Script):
     def ui(self, is_img2img):
         unsinify = gr.Checkbox(label='Reduce effect of sin() during interpolation', value=True)
         dest_seed = gr.Textbox(label="Destination seed(s) (Comma separated)", lines=1)
-        steps = gr.Textbox(label="Steps", lines=1)
+        steps = gr.Number(label="Steps", value=10)
 
         return [dest_seed, steps, unsinify]
+
+    def get_next_sequence_number(path):
+        from pathlib import Path
+        """
+        Determines and returns the next sequence number to use when saving an image in the specified directory.
+
+        The sequence starts at 0.
+        """
+        result = -1
+        dir = Path(path)
+        for file in dir.iterdir():
+            if not file.is_dir(): continue
+            try:
+                num = int(file.name)
+                if num > result: result = num
+            except ValueError:
+                pass
+        return result + 1
 
     def run(self, p, dest_seed, steps, unsinify):
         initial_info = None
         images = []
 
+        # Custom seed travel saving
+        travel_path = os.path.join(p.outpath_samples, "travels")
+        os.makedirs(travel_path, exist_ok=True)
+        travel_number = Script.get_next_sequence_number(travel_path)
+        travel_path = os.path.join(travel_path, f"{travel_number:05}")
+        p.outpath_samples = travel_path
+
         start_seed = p.seed
         seeds = [int(x.strip()) for x in dest_seed.split(",")]
-        print(f"Generating {((int(steps)) * len(seeds)) + 1} images.")
+        total_images = int(steps) * len(seeds) + 1
+        print(f"Generating {total_images} images.")
+        state.job_count = total_images # Set the job count to the total number of images to be generated
         for next_seed in seeds:
             p.seed = start_seed
             p.subseed = next_seed

--- a/scripts/seed_travel.py
+++ b/scripts/seed_travel.py
@@ -17,8 +17,9 @@ class Script(scripts.Script):
         unsinify = gr.Checkbox(label='Reduce effect of sin() during interpolation', value=True)
         dest_seed = gr.Textbox(label="Destination seed(s) (Comma separated)", lines=1)
         steps = gr.Number(label="Steps", value=10)
+        save_video = gr.Checkbox(label='Save results as video', value=True)
 
-        return [dest_seed, steps, unsinify]
+        return [dest_seed, steps, unsinify, save_video]
 
     def get_next_sequence_number(path):
         from pathlib import Path
@@ -38,7 +39,7 @@ class Script(scripts.Script):
                 pass
         return result + 1
 
-    def run(self, p, dest_seed, steps, unsinify):
+    def run(self, p, dest_seed, steps, unsinify, save_video):
         initial_info = None
         images = []
 
@@ -74,6 +75,12 @@ class Script(scripts.Script):
         p.subseed_strength = 0.0
         proc = process_images(p)
         images += proc.images
+
+        if save_video:
+            import moviepy.video.io.ImageSequenceClip as ImageSequenceClip
+            import numpy as np
+            clip = ImageSequenceClip.ImageSequenceClip([np.asarray(i) for i in images], fps=30)
+            clip.write_videofile(os.path.join(travel_path, f"travel-{travel_number:05}.mp4"), verbose=False, logger=None)
 
         processed = Processed(p, images, p.seed, initial_info)
 


### PR DESCRIPTION
So there are two features that were added here, let me know if you want me to break them out into separate PRs.

**Features:**
1. Save generated images into a `travels/{sequence_number}/` folder instead of in the same place as standard txt2img generations
2. Add the option to save as a video upon completion. This requires the addition of a pip module `moviepy`, the additional installation step has been added to the README accordingly.
3. Add overall job tracking for the full seed travel