### PR TITLE
deps: add imageio-ffmpeg requirement to install.py

### DIFF
--- a/install.py
+++ b/install.py
@@ -2,3 +2,6 @@ import launch
 
 if not launch.is_installed("moviepy"):
     launch.run_pip("install moviepy==1.0.3", "requirements for Seed Travel")
+
+if not launch.is_installed("imageio-ffmpeg"):
+    launch.run_pip("install imageio-ffmpeg", "requirements for Seed Travel")


### PR DESCRIPTION
Fixes #41 by adding imageio-ffmpeg to extension requirements/dependencies.

This is required due to some changes with moviepy's underlying imageio library, which has deprecated/removed the old autoinstallation method around 2019-ish, and as such moviepy is no longer capable of autoinstalling ffmpeg.

See [Zulko/moviepy#906](https://github.com/Zulko/moviepy/issues/906) and [Zulko/moviepy#908](https://github.com/Zulko/moviepy/issues/908) for further details on the moviepy side.

This does result in downloading ffmpeg on systems where it may already be installed, but it's a reasonably small download and on some systems (eg Ubuntu 22.04) moviepy 1.0.3 fails to pick up system ffmpeg anyway.